### PR TITLE
ci: enforce PR branch naming policy

### DIFF
--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -1,0 +1,29 @@
+name: branch-name-policy
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate source branch name
+        shell: bash
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          echo "Checking branch: $BRANCH"
+
+          if [[ "$BRANCH" =~ ^feature\/[a-z0-9._-]+$ ]] || \
+             [[ "$BRANCH" =~ ^hotfix\/[a-z0-9._-]+$ ]] || \
+             [[ "$BRANCH" =~ ^release\/[a-z0-9._-]+$ ]]; then
+            echo "Branch name is valid"
+            exit 0
+          fi
+
+          echo "Invalid branch name: $BRANCH"
+          echo "Allowed patterns:"
+          echo "  - feature/<name>"
+          echo "  - hotfix/<name>"
+          echo "  - release/<name>"
+          exit 1


### PR DESCRIPTION
## Summary
  Add a GitHub Actions workflow to validate PR source branch names against team naming conventions.

## What Changed
- Added `.github/workflows/branch-name-policy.yml`
- New check job: `validate-branch-name`
- Trigger: `pull_request` (`opened`, `edited`, `synchronize`, `reopened`)

## Allowed Branch Patterns
- `feature/<name>`
- `hotfix/<name>`
- `release/<name>`

## Why
Standardize branch naming for clearer release flow and easier automation/ruleset enforcement.

## Follow-up (Repo Settings)
Add `validate-branch-name` as a required status check in branch rulesets for:
- `main`
- `stage`
- `develop`