### PR TITLE
ci: reduce Actions cost with scoped triggers and concurrency cancellation

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -2,8 +2,30 @@ name: backend-ci
 
 on:
   push:
-    branches: ["**"]
+    branches: [main, develop, stage]
+    paths:
+      - "apps/api/**"
+      - "packages/contracts-auth/**"
+      - ".github/workflows/backend-ci.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+      - "docker-compose.yml"
   pull_request:
+    paths:
+      - "apps/api/**"
+      - "packages/contracts-auth/**"
+      - ".github/workflows/backend-ci.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+      - "docker-compose.yml"
+
+concurrency:
+  group: backend-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   api-check:

--- a/.github/workflows/design-system-ci.yml
+++ b/.github/workflows/design-system-ci.yml
@@ -2,7 +2,7 @@ name: design-system-ci
 
 on:
   push:
-    branches: ["**"]
+    branches: [main, develop, stage]
     paths:
       - "apps/storybook/**"
       - "packages/ui/**"
@@ -22,6 +22,10 @@ on:
       - "pnpm-workspace.yaml"
       - "turbo.json"
       - "tsconfig.base.json"
+
+concurrency:
+  group: design-system-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   design-system-check:


### PR DESCRIPTION
## Summary
Optimize GitHub Actions usage to reduce unnecessary runs/minutes while keeping required quality gates.

## What Changed
- Updated `.github/workflows/backend-ci.yml`
    - Added `concurrency` with `cancel-in-progress: true`
    - Scoped `push` branches to `main`, `develop`, `stage`
    - Added backend-relevant `paths` filters
- Updated `.github/workflows/design-system-ci.yml`
    - Added `concurrency` with `cancel-in-progress: true`
    - Scoped `push` branches to `main`, `develop`, `stage`
    - Kept design-system-specific `paths` filters

## Why
- Prevent duplicate in-progress runs on the same ref
- Avoid running backend CI for unrelated design-system changes (and vice versa)
- Reduce billed Actions minutes without lowering check quality

## Impact
- Lower CI minute consumption and queue noise
- Faster feedback for relevant changes
- No runtime application behavior changes (CI config only)

## Validation
- Workflow triggers and path filters reviewed for expected scope
- Existing required checks remain intact (`api-check`, `design-system-check`, `validate-branch-name`)