### PR TITLE
feat(repo): add Codex issue intake templates, triage policy, and auto label sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/codex-blocker-resolution.yml
+++ b/.github/ISSUE_TEMPLATE/codex-blocker-resolution.yml
@@ -1,0 +1,42 @@
+name: Codex Blocker Resolution
+description: Record maintainer actions that unblock a previously blocked Codex issue.
+title: "[codex-unblock] "
+labels:
+  - codex:blocked
+  - needs:maintainer
+body:
+  - type: input
+    id: blocked_issue
+    attributes:
+      label: Blocked Issue Number or Link
+      placeholder: "#123 or https://github.com/org/repo/issues/123"
+    validations:
+      required: true
+
+  - type: textarea
+    id: completed_actions
+    attributes:
+      label: Completed Human Actions
+      description: What was completed to unblock Codex?
+      placeholder: |
+        - Access granted to ...
+        - Decision approved for ...
+        - External dependency prepared ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / Links
+      description: PR links, screenshots, logs, policy references.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: ready
+    attributes:
+      label: Ready for Resume
+      options:
+        - label: I confirm Codex can continue from this point.
+          required: true

--- a/.github/ISSUE_TEMPLATE/codex-work-request.yml
+++ b/.github/ISSUE_TEMPLATE/codex-work-request.yml
@@ -1,0 +1,127 @@
+name: Codex Work Request
+description: Request Codex-driven implementation, review, or refinement with clear acceptance criteria.
+title: "[codex] "
+labels:
+  - codex:triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for Codex intake.
+        Codex will decide whether it can execute autonomously or needs maintainer action first.
+
+  - type: dropdown
+    id: request_kind
+    attributes:
+      label: Request Kind
+      options:
+        - feature
+        - bug
+        - chore
+        - docs
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - p0
+        - p1
+        - p2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - web
+        - api
+        - infra
+        - spec
+        - ci
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Goal
+      description: What should be solved and why now?
+      placeholder: Current pain and desired outcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What should users/developers observe after completion?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope (In / Out)
+      description: Define in-scope and explicitly out-of-scope items.
+      placeholder: |
+        In:
+        - ...
+        Out:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Testable checklist. Each item should be verifiable.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints / Risks
+      description: Security, compliance, access limits, env requirements, deadlines.
+      placeholder: Credentials, external services, data migration, approvals, etc.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: autonomous_possible
+    attributes:
+      label: Can Codex execute end-to-end without human work?
+      options:
+        - "yes"
+        - "no"
+        - "unsure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: required_human_action
+    attributes:
+      label: Required Human Action (if no/unsure)
+      description: Exact maintainer actions Codex cannot perform.
+      placeholder: Access grant, business decision, manual verification, external approval, etc.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: quality_gate
+    attributes:
+      label: Quality Gate
+      options:
+        - label: I provided enough detail for spec -> plan -> tasks derivation.
+          required: true
+        - label: I understand Codex may mark this as blocked and request maintainer action.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/workflows/codex-issue-label-sync.yml
+++ b/.github/workflows/codex-issue-label-sync.yml
@@ -1,0 +1,82 @@
+name: codex-issue-label-sync
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Sync kind/prio/area labels from issue form
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue
+            if (!issue || issue.pull_request) {
+              return
+            }
+
+            const body = issue.body || ""
+            const parseSingleValue = (sectionTitle) => {
+              const re = new RegExp(`###\\s+${sectionTitle}\\s*\\n+([^\\n\\r]+)`, "i")
+              const m = body.match(re)
+              return m ? m[1].trim().toLowerCase() : ""
+            }
+
+            const requestKind = parseSingleValue("Request Kind")
+            const priority = parseSingleValue("Priority")
+            const area = parseSingleValue("Area")
+
+            if (!requestKind && !priority && !area) {
+              core.info("Issue does not look like Codex Work Request form. Skip.")
+              return
+            }
+
+            const desired = []
+            const kindSet = new Set(["feature", "bug", "chore", "docs"])
+            const prioSet = new Set(["p0", "p1", "p2"])
+            const areaSet = new Set(["web", "api", "infra", "spec", "ci"])
+
+            if (kindSet.has(requestKind)) desired.push(`kind:${requestKind}`)
+            if (prioSet.has(priority)) desired.push(`prio:${priority}`)
+            if (areaSet.has(area)) desired.push(`area:${area}`)
+
+            const { data: repoLabels } = await github.rest.issues.listLabelsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            })
+            const repoLabelNames = new Set(repoLabels.map((l) => l.name))
+            const existing = issue.labels.map((l) => l.name)
+
+            const groupedPrefixes = ["kind:", "prio:", "area:"]
+            const removable = existing.filter((name) =>
+              groupedPrefixes.some((p) => name.startsWith(p)),
+            )
+
+            for (const label of removable) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                name: label,
+              }).catch(() => {})
+            }
+
+            const addable = desired.filter((name) => repoLabelNames.has(name))
+            if (addable.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: addable,
+              })
+            }
+
+            core.info(`Synced labels: ${addable.join(", ") || "(none)"}`)

--- a/docs/codex-maintainer-comment-template.md
+++ b/docs/codex-maintainer-comment-template.md
@@ -1,0 +1,42 @@
+# Codex Maintainer Comment Templates
+
+Use these templates on GitHub issues for consistent Codex-human handoff.
+
+## Blocked Notice
+
+```md
+Status: blocked
+
+Reason:
+- <short blocker summary>
+
+What Codex checked:
+- <check 1>
+- <check 2>
+
+Required maintainer actions:
+- [ ] <action 1>
+- [ ] <action 2>
+
+After completion, comment:
+/codex resume
+```
+
+## Ready Notice
+
+```md
+Status: ready
+
+Codex can execute this issue end-to-end.
+Next steps:
+- create branch `feature/<task-name>`
+- generate/update spec -> plan -> tasks
+- implement and validate against acceptance criteria
+```
+
+## Resume Confirmation
+
+```md
+Maintainer actions confirmed.
+Codex may continue from this issue state.
+```

--- a/docs/issue-triage-policy.md
+++ b/docs/issue-triage-policy.md
@@ -1,0 +1,105 @@
+# Codex Issue Triage Policy
+
+This document defines how issues are prepared and triaged for Codex-driven execution.
+
+## Intake Flow
+
+1. Reporter opens a GitHub issue with `Codex Work Request`.
+2. Issue starts with label `codex:triage`.
+3. Codex evaluates issue completeness and execution feasibility.
+4. Codex moves the issue into one of two paths:
+   - Autonomous path: `codex:ready` -> `codex:running` -> `codex:done`
+   - Blocked path: `codex:blocked` + one or more `needs:*` labels
+
+Initial automation in repository:
+
+- `.github/workflows/codex-issue-label-sync.yml` syncs `kind:*`, `prio:*`, `area:*` from issue form fields.
+
+## Label Bootstrap
+
+Seed or update labels with GitHub CLI:
+
+```powershell
+pwsh ./tooling/seed-github-labels.ps1 -Repo "<owner>/<repo>"
+```
+
+## Label Taxonomy
+
+### Work classification
+
+- `kind:feature`
+- `kind:bug`
+- `kind:chore`
+- `kind:docs`
+
+### Priority
+
+- `prio:p0`
+- `prio:p1`
+- `prio:p2`
+
+### Area
+
+- `area:web`
+- `area:api`
+- `area:infra`
+- `area:spec`
+- `area:ci`
+
+### Codex state
+
+- `codex:triage`
+- `codex:ready`
+- `codex:running`
+- `codex:blocked`
+- `codex:done`
+
+### Human dependency
+
+- `needs:maintainer`
+- `needs:product`
+- `needs:access`
+- `needs:decision`
+
+## Autonomous Decision Rules
+
+Codex can execute end-to-end only when all are true:
+
+- Problem, scope, and acceptance criteria are clear and testable.
+- Required access and environment are already available.
+- No external manual steps are required during execution.
+- No high-risk policy gate is involved (secrets, destructive infra changes, compliance-only decisions).
+
+If any condition fails, Codex must switch to blocked mode.
+
+## Blocked Mode Rules
+
+When blocked, Codex should:
+
+1. Set `codex:blocked`.
+2. Add matching `needs:*` labels.
+3. Post a maintainer-action comment containing:
+   - Block reason
+   - What Codex already checked
+   - Required human actions (checklist)
+   - Resume trigger (`/codex resume`)
+
+Maintainers can use `Codex Blocker Resolution` template to confirm unblocking.
+
+## Spec-Kit Alignment
+
+After triage, implementation-ready issues must map into spec-kit flow:
+
+1. `spec.md`
+2. `plan.md`
+3. `tasks.md`
+
+All feature docs must include:
+
+- `Tech-Stack: specs/00-tech-stack.md`
+
+Branch naming must follow repository policy:
+
+- `feature/<name>`
+- `hotfix/<name>`
+- `release/<name>`

--- a/specs/04-codex-issue-autoflow/plan.md
+++ b/specs/04-codex-issue-autoflow/plan.md
@@ -1,0 +1,70 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Implementation Plan: Codex Issue Autoflow
+
+**Branch**: `feature/codex-issue-autoflow` | **Date**: 2026-02-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/04-codex-issue-autoflow/spec.md`
+
+## Summary
+
+이 기능은 운영 기반(문서/템플릿) + 초기 자동화(라벨 동기화) 단계다.
+우선 GitHub issue 템플릿과 triage 정책을 고정하고, `kind/prio/area` 자동 동기화를 도입한다.
+고급 자동화(브랜치 생성/실행/PR 자동화)는 후속 단계로 분리한다.
+
+## Technical Context
+
+- **Platform**: GitHub Issues / Labels / Issue Forms
+- **Repository Policy**: branch naming policy + spec-kit workflow
+- **Reference SSOT**: `specs/00-tech-stack.md`
+- **Deliverable Type**: Markdown docs + `.github/ISSUE_TEMPLATE/*`
+
+## Constitution Check
+
+- SSOT 준수: 문서 상단 Tech-Stack 참조 포함
+- Local-first: 로컬에서 문서 검토/수정 가능
+- Boundary: 본 단계는 프로세스 정립 중심, 런타임 자동화는 후속 단계
+
+## Project Structure
+
+```text
+.github/
+└── ISSUE_TEMPLATE/
+    ├── config.yml
+    ├── codex-work-request.yml
+    └── codex-blocker-resolution.yml
+
+docs/
+├── issue-triage-policy.md
+└── codex-maintainer-comment-template.md
+
+specs/04-codex-issue-autoflow/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+## Phases
+
+1. Intake form 정의 (required fields, autonomous 여부)
+2. Label taxonomy 및 상태 전이 규칙 문서화
+3. Blocked handoff 코멘트 템플릿 문서화
+4. Spec-kit 연동 규칙 명시
+5. 운영 리뷰 (maintainer 관점 refine)
+6. 초기 자동화: issue form -> label sync workflow 적용
+7. 후속 자동화(명령 트리거/실행 자동화)는 별도 기능으로 분리
+
+## Risks and Mitigations
+
+- 리스크: 라벨 규칙 과복잡
+  완화: 최소 라벨 집합부터 시작 후 운영 데이터 기반 확장
+- 리스크: blocked 기준 모호
+  완화: autonomous 가능 조건을 checklist 형태로 명문화
+- 리스크: 템플릿이 현실 이슈와 불일치
+  완화: 2주 운영 후 필드/라벨 개선 사이클 수행
+
+## Exit Criteria
+
+- Intake/blocked 템플릿 추가 완료
+- triage 정책 문서 추가 완료
+- label sync workflow 추가 완료
+- spec/plan/tasks 초안 리뷰 완료

--- a/specs/04-codex-issue-autoflow/spec.md
+++ b/specs/04-codex-issue-autoflow/spec.md
@@ -1,0 +1,76 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Feature Specification: Codex Issue Autoflow
+
+**Feature Branch**: `feature/codex-issue-autoflow`  
+**Created**: 2026-02-27  
+**Status**: In Progress (Initial automation added: label sync workflow)  
+**Input**: "issue intake -> codex triage -> autonomous work or maintainer-blocked handoff flow"
+
+## Scope
+
+- 포함: GitHub issue form 템플릿, 라벨 정책, triage/handoff 운영 문서
+- 포함: issue form 기반 `kind/prio/area` 자동 라벨 동기화 워크플로우(초기 자동화)
+- 포함: spec-kit 연동 규칙(spec -> plan -> tasks) 정의
+- 제외: 완전 자동 구현(실제 bot 실행/branch 생성/PR 작성 전체 자동화)
+
+## Problem Statement
+
+현재는 이슈가 들어왔을 때 Codex가 바로 실행 가능한지, 사람 개입이 필요한지 기준이 표준화되어 있지 않다.  
+그 결과, 이슈 품질 편차와 handoff 지연이 발생한다.
+
+## Goals
+
+1. 이슈 입력 품질을 표준화한다.
+2. Codex triage 결과를 라벨 상태로 명확히 표현한다.
+3. 사람 개입이 필요한 경우 maintainer action을 구조화한다.
+4. 구현 전 단계에서 spec-kit 문서 흐름과 정합성을 보장한다.
+
+## User Scenarios & Testing
+
+### User Story 1 - Reporter intake 표준화 (Priority: P1)
+
+Reporter는 단일 양식으로 문제/범위/수용기준을 제출한다.
+
+**Independent Test**: 새 이슈가 템플릿 필수 항목 없이 생성되지 않는다.
+
+### User Story 2 - Codex triage 상태 관리 (Priority: P1)
+
+Codex/maintainer는 라벨로 현재 상태(ready/running/blocked/done)를 추적한다.
+
+**Independent Test**: 임의 이슈 3건을 샘플 triage할 때 상태 전이 규칙이 일관된다.
+
+### User Story 3 - Blocked handoff 명확화 (Priority: P2)
+
+사람 작업이 필요하면 maintainer에게 필요한 행동이 체크리스트로 전달된다.
+
+**Independent Test**: blocked 템플릿으로 unblocking 후 `/codex resume` 재개가 가능하다.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-CIA-001**: 저장소는 Codex 전용 issue intake 템플릿을 제공해야 한다.
+- **FR-CIA-002**: intake 템플릿은 problem/scope/acceptance criteria를 필수로 수집해야 한다.
+- **FR-CIA-003**: 저장소는 blocker 해제(maintainer action 완료) 템플릿을 제공해야 한다.
+- **FR-CIA-004**: triage 정책 문서는 라벨 taxonomy와 상태 전이 규칙을 정의해야 한다.
+- **FR-CIA-005**: 정책 문서는 autonomous 실행 기준과 blocked 기준을 모두 명시해야 한다.
+- **FR-CIA-006**: blocked 시 maintainer comment 템플릿을 제공해야 한다.
+- **FR-CIA-007**: spec-kit 정합 규칙(Tech-Stack header, spec->plan->tasks)을 정책에 포함해야 한다.
+- **FR-CIA-008**: 본 기능의 spec/plan/tasks 문서는 `Tech-Stack: specs/00-tech-stack.md`를 포함해야 한다.
+- **FR-CIA-009**: Codex Work Request form의 `Request Kind/Priority/Area` 값은 `kind:*/prio:*/area:*` 라벨로 자동 동기화되어야 한다.
+
+### Key Entities
+
+- **Codex Work Request**: 구현/수정/정제 요청을 정의하는 intake issue
+- **Codex State Label**: `triage/ready/running/blocked/done` 상태 표현 라벨
+- **Human Dependency Label**: `needs:*` 계열 의존성 라벨
+- **Maintainer Action Comment**: blocked 해소를 위한 체크리스트 코멘트
+
+## Success Criteria
+
+- **SC-CIA-001**: 새 이슈는 표준 intake 템플릿으로 생성 가능해야 한다.
+- **SC-CIA-002**: triage 정책 문서에서 라벨/상태 전이/결정 기준이 누락 없이 정의되어야 한다.
+- **SC-CIA-003**: blocked/ready 코멘트 템플릿을 통해 maintainer handoff 시간이 단축되어야 한다.
+- **SC-CIA-004**: 다음 단계(자동화 구현) 전에 문서 리뷰로 운영 절차 합의가 완료되어야 한다.
+- **SC-CIA-005**: issue 생성/수정 시 `kind/prio/area` 라벨 자동 동기화가 일관되게 동작해야 한다.

--- a/specs/04-codex-issue-autoflow/tasks.md
+++ b/specs/04-codex-issue-autoflow/tasks.md
@@ -1,0 +1,46 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Tasks: Codex Issue Autoflow
+
+## Execution Rule
+
+- 우선순위: `P1 -> P2`
+- 본 단계는 운영 문서/템플릿 정립까지 수행
+- bot/automation 구현은 후속 기능으로 분리
+
+## Phase 1: Intake Foundation (P1)
+
+- [x] CIA-T001 `.github/ISSUE_TEMPLATE/config.yml` 추가
+- [x] CIA-T002 `codex-work-request.yml` 템플릿 추가
+- [x] CIA-T003 필수 항목(problem/scope/acceptance criteria/autonomous 여부) 반영
+
+## Phase 2: Blocked Handoff Foundation (P1)
+
+- [x] CIA-T004 `codex-blocker-resolution.yml` 템플릿 추가
+- [x] CIA-T005 blocked -> resume 운영 절차 문서화
+- [x] CIA-T006 maintainer 코멘트 템플릿 문서 추가
+
+## Phase 3: Policy Documentation (P1)
+
+- [x] CIA-T007 label taxonomy 문서화
+- [x] CIA-T008 autonomous vs blocked decision rule 문서화
+- [x] CIA-T009 spec-kit 정합 규칙(Tech-Stack, spec->plan->tasks) 명시
+- [x] CIA-T009A GitHub label bootstrap 스크립트 추가 (`tooling/seed-github-labels.ps1`)
+
+## Phase 4: Spec Kit Alignment (P2)
+
+- [x] CIA-T010 `specs/04-codex-issue-autoflow/spec.md` 작성
+- [x] CIA-T011 `specs/04-codex-issue-autoflow/plan.md` 작성
+- [x] CIA-T012 `specs/04-codex-issue-autoflow/tasks.md` 작성
+- [ ] CIA-T013 운영 리뷰 후 refine cycle 반영
+
+## Phase 5: Initial Automation (P2)
+
+- [x] CIA-T014 issue form 필드(`Request Kind/Priority/Area`)를 라벨로 동기화하는 GitHub Action 추가
+- [x] CIA-T015 라벨 동기화 시 기존 `kind:/prio:/area:` 그룹 라벨 정리 후 재적용 규칙 반영
+
+## Done Checklist
+
+- [x] FR-CIA-001~009 문서/템플릿/초기 자동화 기준 충족
+- [x] 운영 기준 문서와 템플릿이 상호 참조 가능
+- [ ] maintainer 실제 trial 1회 이상 수행

--- a/tooling/seed-github-labels.ps1
+++ b/tooling/seed-github-labels.ps1
@@ -1,0 +1,41 @@
+param(
+  [string]$Repo = ""
+)
+
+$labels = @(
+  @{ Name = "kind:feature"; Color = "0E8A16"; Description = "Feature work" },
+  @{ Name = "kind:bug"; Color = "D73A4A"; Description = "Bug fix work" },
+  @{ Name = "kind:chore"; Color = "FBCA04"; Description = "Maintenance or chore" },
+  @{ Name = "kind:docs"; Color = "1D76DB"; Description = "Documentation work" },
+
+  @{ Name = "prio:p0"; Color = "B60205"; Description = "Critical priority" },
+  @{ Name = "prio:p1"; Color = "D93F0B"; Description = "High priority" },
+  @{ Name = "prio:p2"; Color = "FBCA04"; Description = "Normal priority" },
+
+  @{ Name = "area:web"; Color = "5319E7"; Description = "Web app area" },
+  @{ Name = "area:api"; Color = "0052CC"; Description = "API area" },
+  @{ Name = "area:infra"; Color = "006B75"; Description = "Infrastructure area" },
+  @{ Name = "area:spec"; Color = "0366D6"; Description = "Spec/process area" },
+  @{ Name = "area:ci"; Color = "C2E0C6"; Description = "CI/CD area" },
+
+  @{ Name = "codex:triage"; Color = "C5DEF5"; Description = "Awaiting Codex triage" },
+  @{ Name = "codex:ready"; Color = "BFDADC"; Description = "Ready for Codex run" },
+  @{ Name = "codex:running"; Color = "0E8A16"; Description = "Codex is executing" },
+  @{ Name = "codex:blocked"; Color = "D93F0B"; Description = "Blocked and needs human action" },
+  @{ Name = "codex:done"; Color = "5319E7"; Description = "Codex work completed" },
+
+  @{ Name = "needs:maintainer"; Color = "F9D0C4"; Description = "Needs maintainer action" },
+  @{ Name = "needs:product"; Color = "F9D0C4"; Description = "Needs product decision" },
+  @{ Name = "needs:access"; Color = "F9D0C4"; Description = "Needs access/credential setup" },
+  @{ Name = "needs:decision"; Color = "F9D0C4"; Description = "Needs explicit decision before coding" }
+)
+
+foreach ($label in $labels) {
+  $args = @("label", "create", $label.Name, "--color", $label.Color, "--description", $label.Description, "--force")
+  if ($Repo) {
+    $args += @("--repo", $Repo)
+  }
+  gh @args
+}
+
+Write-Output "Label sync complete."


### PR DESCRIPTION
## Summary

  - Added a Codex-first issue intake flow for GitHub Issues.
  - Added a blocker resolution template for maintainer handoff.
  - Added triage policy and maintainer comment templates.
  - Added automated label sync workflow to map issue form fields into kind:*, prio:*, area:*.
  - Added spec-kit package for this feature (spec/plan/tasks) aligned with specs/00-tech-stack.md.

  ## Changes

  - Issue templates
      - .github/ISSUE_TEMPLATE/codex-work-request.yml
      - .github/ISSUE_TEMPLATE/codex-blocker-resolution.yml
      - .github/ISSUE_TEMPLATE/config.yml
  - Workflow
      - .github/workflows/codex-issue-label-sync.yml
  - Docs
      - docs/issue-triage-policy.md
      - docs/codex-maintainer-comment-template.md
  - Tooling
      - tooling/seed-github-labels.ps1
  - Specs
      - specs/04-codex-issue-autoflow/spec.md
      - specs/04-codex-issue-autoflow/plan.md
      - specs/04-codex-issue-autoflow/tasks.md

  ## Automation Behavior

  - Trigger: issues (opened, edited, reopened)
  - Input parsing from issue form sections:
      - Request Kind -> kind:*
      - Priority -> prio:*
      - Area -> area:*
  - Existing grouped labels (kind:/prio:/area:) are removed then normalized labels are applied.
  - Non-form issues are safely skipped.

  ## Validation Notes

  - Label sync logic is aligned to Codex Work Request field titles.
  - Malformed/non-form issue bodies do not get forced label changes.
  - Real usage requires label bootstrap in target repo:

  pwsh ./tooling/seed-github-labels.ps1 -Repo "<owner>/<repo>"

  ## Follow-up (separate PR)

  - Add command-based state transitions (/codex run, /codex resume) and codex state label automation (codex:ready/running/blocked/done).