### PR TITLE
feat(repo): add Codex issue progress notifications (Telegram + issue comments)

### DIFF
--- a/.github/workflows/codex-issue-progress-notify.yml
+++ b/.github/workflows/codex-issue-progress-notify.yml
@@ -1,0 +1,87 @@
+name: codex-issue-progress-notify
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  notify:
+    if: |
+      github.event.label.name == 'spec-done' ||
+      github.event.label.name == 'plan-done' ||
+      github.event.label.name == 'tasks-done'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Build message payload
+        id: payload
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = context.payload.label.name
+            const issue = context.payload.issue
+            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`
+            const issueUrl = `${repoUrl}/issues/${issue.number}`
+
+            const phaseMap = {
+              "spec-done": "Spec phase completed",
+              "plan-done": "Plan phase completed",
+              "tasks-done": "Tasks phase completed",
+            }
+
+            const phaseText = phaseMap[label] ?? label
+            const text = [
+              "Codex issue progress update",
+              `Repo: ${context.repo.owner}/${context.repo.repo}`,
+              `Issue: #${issue.number} ${issue.title}`,
+              `Phase: ${phaseText}`,
+              `Label: ${label}`,
+              `Link: ${issueUrl}`,
+            ].join("\n")
+
+            core.setOutput("phase_label", label)
+            core.setOutput("phase_text", phaseText)
+            core.setOutput("issue_url", issueUrl)
+            core.setOutput("tg_text", text)
+
+      - name: Send Telegram notification
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TG_TEXT: ${{ steps.payload.outputs.tg_text }}
+        run: |
+          if [ -z "${TELEGRAM_BOT_TOKEN}" ] || [ -z "${TELEGRAM_CHAT_ID}" ]; then
+            echo "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID is not set. Skipping Telegram."
+            exit 0
+          fi
+
+          curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${TG_TEXT}" \
+            -d "disable_web_page_preview=true"
+
+      - name: Comment on issue
+        uses: actions/github-script@v7
+        env:
+          PHASE_LABEL: ${{ steps.payload.outputs.phase_label }}
+          PHASE_TEXT: ${{ steps.payload.outputs.phase_text }}
+        with:
+          script: |
+            const body = [
+              "Codex progress update",
+              "",
+              `- Status: ${process.env.PHASE_TEXT}`,
+              `- Label: \`${process.env.PHASE_LABEL}\``,
+              "- Notification: Telegram + GitHub issue comment",
+            ].join("\n")
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body,
+            })

--- a/docs/issue-triage-policy.md
+++ b/docs/issue-triage-policy.md
@@ -54,6 +54,12 @@ pwsh ./tooling/seed-github-labels.ps1 -Repo "<owner>/<repo>"
 - `codex:blocked`
 - `codex:done`
 
+### Progress notifications
+
+- `spec-done`
+- `plan-done`
+- `tasks-done`
+
 ### Human dependency
 
 - `needs:maintainer`

--- a/docs/telegram-bot-template.md
+++ b/docs/telegram-bot-template.md
@@ -1,0 +1,55 @@
+# Telegram Bot Template for Codex Issue Updates
+
+Use this template to connect GitHub issue progress events to Telegram notifications.
+
+## 1) Create Telegram Bot
+
+1. Open Telegram and start chat with `@BotFather`.
+2. Run `/newbot`.
+3. Save the bot token (format: `123456:ABC...`).
+
+## 2) Get Chat ID
+
+Option A (private chat):
+
+1. Send any message to your bot.
+2. Open:
+   `https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates`
+3. Find `chat.id` value.
+
+Option B (group chat):
+
+1. Add bot to group.
+2. Send message in group.
+3. Use `getUpdates` and copy group `chat.id` (usually negative integer).
+
+## 3) Set GitHub Secrets
+
+Repository -> Settings -> Secrets and variables -> Actions -> New repository secret
+
+- `TELEGRAM_BOT_TOKEN` = your bot token
+- `TELEGRAM_CHAT_ID` = target chat id
+
+## 4) Trigger Events
+
+Workflow: `.github/workflows/codex-issue-progress-notify.yml`
+
+Triggered when one of labels is added to an issue:
+
+- `spec-done`
+- `plan-done`
+- `tasks-done`
+
+## 5) Expected Outputs
+
+- Telegram message with repository, issue, phase, and issue URL
+- GitHub issue comment describing current phase update
+
+## 6) Test Procedure
+
+1. Create a test issue.
+2. Add label `spec-done`.
+3. Verify:
+   - Actions run success
+   - Telegram message delivered
+   - issue comment created

--- a/specs/05-codex-telegram-issue-notify/plan.md
+++ b/specs/05-codex-telegram-issue-notify/plan.md
@@ -1,0 +1,48 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Implementation Plan: Codex Telegram Issue Notify
+
+**Branch**: `feature/codex-telegram-issue-notify` | **Date**: 2026-02-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/05-codex-telegram-issue-notify/spec.md`
+
+## Summary
+
+Codex progress label 이벤트를 기반으로 Telegram 알림 + GitHub issue comment를 자동 생성한다.
+알림은 phase 추적을 위한 운영 보조 채널이며, secret 미설정 환경에서도 실패하지 않도록 설계한다.
+
+## Technical Context
+
+- **Platform**: GitHub Actions (`issues:labeled`)
+- **External API**: Telegram Bot API (`sendMessage`)
+- **Secrets**:
+  - `TELEGRAM_BOT_TOKEN`
+  - `TELEGRAM_CHAT_ID`
+- **Repository artifacts**:
+  - workflow (`.github/workflows/codex-issue-progress-notify.yml`)
+  - setup docs (`docs/telegram-bot-template.md`)
+  - label bootstrap (`tooling/seed-github-labels.ps1`)
+
+## Phases
+
+1. Phase label 정의(`spec-done`,`plan-done`,`tasks-done`)
+2. workflow 트리거 조건 구성 (`issues:labeled`)
+3. Telegram payload 생성/전송
+4. issue comment audit trail 작성
+5. secret 누락 시 graceful skip 처리
+6. 운영 문서화(봇 생성/secret 설정/테스트 절차)
+
+## Risks and Mitigations
+
+- 리스크: secret 미설정으로 알림 누락
+  완화: workflow 로그에 skip 사유 명시 + issue comment는 항상 생성
+- 리스크: 라벨 오탈자/정의 누락
+  완화: label seed script에 phase label 포함
+- 리스크: 알림 과다
+  완화: phase 완료 라벨 3종 이벤트만 트리거
+
+## Exit Criteria
+
+- workflow 파일 추가 완료
+- Telegram setup template 문서 추가 완료
+- label seed script에 phase label 반영 완료
+- spec/plan/tasks 문서화 완료

--- a/specs/05-codex-telegram-issue-notify/spec.md
+++ b/specs/05-codex-telegram-issue-notify/spec.md
@@ -1,0 +1,53 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Feature Specification: Codex Telegram Issue Notify
+
+**Feature Branch**: `feature/codex-telegram-issue-notify`  
+**Created**: 2026-02-27  
+**Status**: In Progress  
+**Input**: "when codex got issues, notify telegram + show codex phase progress + write issue comment"
+
+## Scope
+
+- 포함: `spec-done/plan-done/tasks-done` 라벨 기반 알림 워크플로우
+- 포함: Telegram bot secret 기반 메시지 전송 템플릿
+- 포함: GitHub issue comment 자동 기록
+- 제외: Codex 실행 자체 자동화(브랜치 생성/코드 구현 자동 시작)
+
+## User Scenarios & Testing
+
+### User Story 1 - Phase progress 알림 (Priority: P1)
+
+Maintainer는 Codex의 문서 단계 진행(`spec/plan/tasks done`)을 Telegram으로 받는다.
+
+**Independent Test**: 이슈에 `spec-done` 라벨 추가 시 Telegram 메시지가 도착한다.
+
+### User Story 2 - Issue audit trail (Priority: P1)
+
+Maintainer는 이슈 내 코멘트로 Codex 단계 진행을 추적할 수 있다.
+
+**Independent Test**: phase label 추가 시 이슈 코멘트가 자동 생성된다.
+
+### User Story 3 - Safe fallback (Priority: P2)
+
+Telegram secret 미설정이어도 워크플로우는 실패하지 않고 코멘트 기록은 유지된다.
+
+**Independent Test**: secret 없이 실행 시 Telegram step skip + issue comment 생성 확인.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-CTN-001**: 저장소는 phase label(`spec-done`,`plan-done`,`tasks-done`)를 정의해야 한다.
+- **FR-CTN-002**: 해당 라벨이 이슈에 추가되면 알림 워크플로우가 실행되어야 한다.
+- **FR-CTN-003**: Telegram 메시지는 repo/issue/phase/link 정보를 포함해야 한다.
+- **FR-CTN-004**: Telegram secret 미설정 시 워크플로우는 실패하지 않고 skip해야 한다.
+- **FR-CTN-005**: phase 라벨 이벤트마다 GitHub issue comment를 자동 작성해야 한다.
+- **FR-CTN-006**: Telegram 설정 방법 문서를 저장소 내에서 제공해야 한다.
+- **FR-CTN-007**: 본 기능 spec/plan/tasks는 `Tech-Stack: specs/00-tech-stack.md`를 포함해야 한다.
+
+## Success Criteria
+
+- **SC-CTN-001**: phase 라벨 추가 시 알림 워크플로우가 일관되게 실행된다.
+- **SC-CTN-002**: Telegram 설정 시 실메시지 전송이 확인된다.
+- **SC-CTN-003**: 각 phase 이벤트에서 issue comment audit trail이 남는다.

--- a/specs/05-codex-telegram-issue-notify/tasks.md
+++ b/specs/05-codex-telegram-issue-notify/tasks.md
@@ -1,0 +1,40 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Tasks: Codex Telegram Issue Notify
+
+## Execution Rule
+
+- 우선순위: `P1 -> P2`
+- phase progress 알림(`spec/plan/tasks done`)에 집중
+- Codex 실행 자동화 자체는 범위 제외
+
+## Phase 1: Label and Trigger Foundation (P1)
+
+- [x] CTN-T001 phase label(`spec-done`,`plan-done`,`tasks-done`) 정의를 label seed script에 반영
+- [x] CTN-T002 `issues:labeled` 이벤트 기반 workflow 파일 추가
+- [x] CTN-T003 phase label 3종에만 반응하도록 조건 구성
+
+## Phase 2: Notification and Comment (P1)
+
+- [x] CTN-T004 Telegram payload 생성(Repo/Issue/Phase/Link)
+- [x] CTN-T005 Telegram API(`sendMessage`) 호출 step 구현
+- [x] CTN-T006 Issue comment 자동 작성 step 구현
+- [x] CTN-T007 secret 미설정 시 skip 처리(실패 방지) 구현
+
+## Phase 3: Documentation (P1)
+
+- [x] CTN-T008 Telegram bot setup 템플릿 문서 추가
+- [x] CTN-T009 운영 테스트 절차 문서화
+
+## Phase 4: Spec Kit Alignment (P2)
+
+- [x] CTN-T010 `spec.md` 작성
+- [x] CTN-T011 `plan.md` 작성
+- [x] CTN-T012 `tasks.md` 작성
+- [ ] CTN-T013 실제 repo secret 설정 후 end-to-end 실검증
+
+## Done Checklist
+
+- [x] FR-CTN-001~007 구현/문서 반영
+- [x] 템플릿 + workflow + label seed script 정합성 확보
+- [ ] Telegram 실메시지 수신 확인

--- a/tooling/seed-github-labels.ps1
+++ b/tooling/seed-github-labels.ps1
@@ -24,6 +24,10 @@ $labels = @(
   @{ Name = "codex:blocked"; Color = "D93F0B"; Description = "Blocked and needs human action" },
   @{ Name = "codex:done"; Color = "5319E7"; Description = "Codex work completed" },
 
+  @{ Name = "spec-done"; Color = "0E8A16"; Description = "Spec phase completed" },
+  @{ Name = "plan-done"; Color = "1D76DB"; Description = "Plan phase completed" },
+  @{ Name = "tasks-done"; Color = "5319E7"; Description = "Tasks phase completed" },
+
   @{ Name = "needs:maintainer"; Color = "F9D0C4"; Description = "Needs maintainer action" },
   @{ Name = "needs:product"; Color = "F9D0C4"; Description = "Needs product decision" },
   @{ Name = "needs:access"; Color = "F9D0C4"; Description = "Needs access/credential setup" },


### PR DESCRIPTION
## Summary

  - Added issue progress notification flow for Codex phase labels:
      - spec-done
      - plan-done
      - tasks-done
  - On phase label add, workflow now:
      - sends Telegram message (if secrets are configured)
      - writes GitHub issue comment as audit trail
  - Added Telegram bot setup template doc.
  - Added new spec-kit package for this feature (05-codex-telegram-issue-notify).

  ## Changes

  - Workflow
      - .github/workflows/codex-issue-progress-notify.yml
  - Docs
      - docs/telegram-bot-template.md
      - docs/issue-triage-policy.md (progress label section added)
  - Tooling
      - tooling/seed-github-labels.ps1 (added spec-done, plan-done, tasks-done)
  - Specs
      - specs/05-codex-telegram-issue-notify/spec.md
      - specs/05-codex-telegram-issue-notify/plan.md
      - specs/05-codex-telegram-issue-notify/tasks.md

  ## Workflow Behavior

  - Trigger: issues event type labeled
  - Condition: only runs for labels spec-done, plan-done, tasks-done
  - Telegram:
      - Uses TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID from GitHub Actions secrets
      - Gracefully skips Telegram step if secrets are missing
  - GitHub comment:
      - Always posts phase progress comment on the issue

  ## Setup Requirements

  Add repository secrets:

  - TELEGRAM_BOT_TOKEN
  - TELEGRAM_CHAT_ID

  (Optional) seed labels:

  pwsh ./tooling/seed-github-labels.ps1 -Repo "<owner>/<repo>"

  ## Validation Plan

  1. Create test issue.
  2. Add spec-done label.
  3. Verify:
      - Actions workflow success
      - Telegram message delivered
      - issue comment created
  4. Repeat with plan-done and tasks-done.