### PR TITLE
feat(repo): add Codex health-check workflow for issue pipeline drift detection

### DIFF
--- a/.github/workflows/codex-health-check.yml
+++ b/.github/workflows/codex-health-check.yml
@@ -1,0 +1,110 @@
+name: codex-health-check
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-codex-pipeline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required Codex files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_files=(
+            ".github/ISSUE_TEMPLATE/codex-work-request.yml"
+            ".github/ISSUE_TEMPLATE/codex-blocker-resolution.yml"
+            ".github/workflows/codex-issue-label-sync.yml"
+            ".github/workflows/codex-issue-progress-notify.yml"
+            "tooling/seed-github-labels.ps1"
+            "docs/issue-triage-policy.md"
+          )
+
+          for file in "${required_files[@]}"; do
+            if [[ ! -f "$file" ]]; then
+              echo "Missing required file: $file"
+              exit 1
+            fi
+          done
+
+      - name: Validate issue form fields for label sync
+        shell: bash
+        run: |
+          set -euo pipefail
+          form=".github/ISSUE_TEMPLATE/codex-work-request.yml"
+
+          grep -q "label: Request Kind" "$form"
+          grep -q "label: Priority" "$form"
+          grep -q "label: Area" "$form"
+
+      - name: Validate label sync workflow rules
+        shell: bash
+        run: |
+          set -euo pipefail
+          wf=".github/workflows/codex-issue-label-sync.yml"
+
+          grep -q "types: \[opened, edited, reopened\]" "$wf"
+          grep -q "Request Kind" "$wf"
+          grep -q "Priority" "$wf"
+          grep -q "Area" "$wf"
+          grep -q "kind:" "$wf"
+          grep -q "prio:" "$wf"
+          grep -q "area:" "$wf"
+
+      - name: Validate progress notify workflow rules
+        shell: bash
+        run: |
+          set -euo pipefail
+          wf=".github/workflows/codex-issue-progress-notify.yml"
+
+          grep -q "types: \[labeled\]" "$wf"
+          grep -q "spec-done" "$wf"
+          grep -q "plan-done" "$wf"
+          grep -q "tasks-done" "$wf"
+          grep -q "TELEGRAM_BOT_TOKEN" "$wf"
+          grep -q "TELEGRAM_CHAT_ID" "$wf"
+          grep -q "createComment" "$wf"
+
+      - name: Validate label seed baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          seed="tooling/seed-github-labels.ps1"
+
+          required_labels=(
+            "codex:triage"
+            "codex:ready"
+            "codex:running"
+            "codex:blocked"
+            "codex:done"
+            "spec-done"
+            "plan-done"
+            "tasks-done"
+            "needs:maintainer"
+          )
+
+          for label in "${required_labels[@]}"; do
+            grep -q "$label" "$seed"
+          done
+
+      - name: Validate policy doc references
+        shell: bash
+        run: |
+          set -euo pipefail
+          policy="docs/issue-triage-policy.md"
+
+          grep -q "codex:triage" "$policy"
+          grep -q "codex:blocked" "$policy"
+          grep -q "spec-done" "$policy"
+          grep -q "plan-done" "$policy"
+          grep -q "tasks-done" "$policy"

--- a/.github/workflows/codex-health-check.yml
+++ b/.github/workflows/codex-health-check.yml
@@ -104,7 +104,10 @@ jobs:
           policy="docs/issue-triage-policy.md"
 
           grep -q "codex:triage" "$policy"
+          grep -q "codex:ready" "$policy"
+          grep -q "codex:running" "$policy"
           grep -q "codex:blocked" "$policy"
+          grep -q "codex:done" "$policy"
           grep -q "spec-done" "$policy"
           grep -q "plan-done" "$policy"
           grep -q "tasks-done" "$policy"

--- a/docs/issue-triage-policy.md
+++ b/docs/issue-triage-policy.md
@@ -14,6 +14,8 @@ This document defines how issues are prepared and triaged for Codex-driven execu
 Initial automation in repository:
 
 - `.github/workflows/codex-issue-label-sync.yml` syncs `kind:*`, `prio:*`, `area:*` from issue form fields.
+- `.github/workflows/codex-issue-progress-notify.yml` posts phase updates to Telegram and issue comments.
+- `.github/workflows/codex-health-check.yml` validates Codex pipeline config daily and on-demand.
 
 ## Label Bootstrap
 

--- a/specs/06-codex-health-check/plan.md
+++ b/specs/06-codex-health-check/plan.md
@@ -1,0 +1,38 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Implementation Plan: Codex Health Check
+
+**Branch**: `feature/codex-health-check` | **Date**: 2026-02-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/06-codex-health-check/spec.md`
+
+## Summary
+
+Codex issue intake/triage/notify 파이프라인의 핵심 설정 drift를 조기에 탐지하기 위한 진단 워크플로우를 추가한다.
+
+## Technical Context
+
+- **Platform**: GitHub Actions
+- **Trigger**:
+  - `workflow_dispatch`
+  - `schedule` (daily)
+- **Validation Method**: shell 기반 정적 규칙 검증 (`grep`, 파일 존재 확인)
+
+## Phases
+
+1. 워크플로우 골격 추가(수동/스케줄)
+2. 필수 파일 존재 검증
+3. form/workflow/label/policy 핵심 규칙 검증
+4. 스펙 문서화 및 운영 반영
+
+## Risks and Mitigations
+
+- 리스크: 문자열 기반 검증의 취약성
+  완화: 운영 중 false positive 발생 시 규칙 세분화
+- 리스크: 검증 범위 과소
+  완화: 신규 Codex 자동화 추가 시 health-check 규칙 동기화 의무화
+
+## Exit Criteria
+
+- health-check workflow 추가 완료
+- spec/plan/tasks 문서 추가 완료
+- 수동 실행 기준 통과 확인(리포에서 1회)

--- a/specs/06-codex-health-check/spec.md
+++ b/specs/06-codex-health-check/spec.md
@@ -1,0 +1,30 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Feature Specification: Codex Health Check
+
+**Feature Branch**: `feature/codex-health-check`  
+**Created**: 2026-02-27  
+**Status**: In Progress  
+**Input**: "github actions health check for codex issue pipeline"
+
+## Scope
+
+- 포함: Codex issue pipeline 핵심 파일/규칙 검증 워크플로우
+- 포함: 수동 실행(`workflow_dispatch`) + 일일 스케줄 실행
+- 제외: 실제 issue 생성/라벨 변경 e2e 실행
+
+## Requirements
+
+- **FR-CHC-001**: `codex-health-check` 워크플로우는 수동/일일 스케줄로 실행되어야 한다.
+- **FR-CHC-002**: Codex 관련 필수 파일 존재 여부를 검증해야 한다.
+- **FR-CHC-003**: issue form 필드(`Request Kind/Priority/Area`) 존재를 검증해야 한다.
+- **FR-CHC-004**: label sync workflow 핵심 규칙을 검증해야 한다.
+- **FR-CHC-005**: progress notify workflow 핵심 규칙을 검증해야 한다.
+- **FR-CHC-006**: label seed script의 핵심 라벨 집합을 검증해야 한다.
+- **FR-CHC-007**: triage policy 문서에 주요 상태/진행 라벨이 포함되어야 한다.
+- **FR-CHC-008**: 본 기능 spec/plan/tasks 문서는 `Tech-Stack: specs/00-tech-stack.md`를 포함해야 한다.
+
+## Success Criteria
+
+- **SC-CHC-001**: 워크플로우가 수동 실행에서 통과한다.
+- **SC-CHC-002**: 핵심 파일/필드/라벨 규칙 drift 발생 시 워크플로우가 실패한다.

--- a/specs/06-codex-health-check/tasks.md
+++ b/specs/06-codex-health-check/tasks.md
@@ -1,0 +1,30 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Tasks: Codex Health Check
+
+## Phase 1: Workflow Setup (P1)
+
+- [x] CHC-T001 `.github/workflows/codex-health-check.yml` 추가
+- [x] CHC-T002 `workflow_dispatch` 트리거 구성
+- [x] CHC-T003 daily `schedule` 트리거 구성
+
+## Phase 2: Rule Validation (P1)
+
+- [x] CHC-T004 Codex 필수 파일 존재 검증 추가
+- [x] CHC-T005 issue form 핵심 필드 검증 추가
+- [x] CHC-T006 label sync workflow 규칙 검증 추가
+- [x] CHC-T007 progress notify workflow 규칙 검증 추가
+- [x] CHC-T008 label seed script 핵심 라벨 검증 추가
+- [x] CHC-T009 policy 문서 참조 라벨 검증 추가
+
+## Phase 3: Spec Kit Alignment (P2)
+
+- [x] CHC-T010 `spec.md` 작성
+- [x] CHC-T011 `plan.md` 작성
+- [x] CHC-T012 `tasks.md` 작성
+- [ ] CHC-T013 GitHub Actions에서 수동 실행 검증
+
+## Done Checklist
+
+- [x] FR-CHC-001~008 기준 반영
+- [ ] workflow_dispatch 실검증 1회 완료


### PR DESCRIPTION
## Summary

- Added a new GitHub Actions workflow to continuously validate Codex issue pipeline integrity.
- Added spec-kit docs for this feature (spec/plan/tasks) aligned to specs/00-tech-stack.md.
- Updated triage policy doc to include health-check workflow reference.

## Changes

- Workflow
    - .github/workflows/codex-health-check.yml
- Docs
    - docs/issue-triage-policy.md (automation section update)
- Specs
    - specs/06-codex-health-check/spec.md
    - specs/06-codex-health-check/plan.md
    - specs/06-codex-health-check/tasks.md

## Workflow Behavior

- Triggers:
    - workflow_dispatch (manual run)
    - schedule daily (0 0 * * *)
- Validations performed:
    - Required Codex files exist
    - Issue form contains Request Kind, Priority, Area
    - codex-issue-label-sync workflow still contains expected sync rules
    - codex-issue-progress-notify workflow still contains expected notify rules
    - tooling/seed-github-labels.ps1 contains required Codex labels
    - docs/issue-triage-policy.md includes key state/progress label references

## Why

- Prevent silent drift in Codex automation configuration.
- Catch template/workflow/policy mismatch early.
- Provide a lightweight daily guardrail plus on-demand verification.

## Validation Plan

1. Open Actions -> run codex-health-check manually.
2. Confirm green run.
3. (Optional) introduce temporary drift in a branch and verify the workflow fails as expected.