### PR TITLE
ci: make required PR checks reliable with conditional execution

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -13,24 +13,42 @@ on:
       - "turbo.json"
       - "docker-compose.yml"
   pull_request:
-    paths:
-      - "apps/api/**"
-      - "packages/contracts-auth/**"
-      - ".github/workflows/backend-ci.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "turbo.json"
-      - "docker-compose.yml"
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: backend-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      backend: ${{ steps.changes.outputs.backend }}
+    steps:
+      - name: Detect relevant changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            backend:
+              - "apps/api/**"
+              - "packages/contracts-auth/**"
+              - ".github/workflows/backend-ci.yml"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
+              - "turbo.json"
+              - "docker-compose.yml"
+
   api-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     env:
       DATABASE_URL: postgresql://kami:ilovekami@localhost:5432/taste_spec_kit
       REDIS_URL: redis://localhost:6379

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -24,12 +24,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       backend: ${{ steps.changes.outputs.backend }}
     steps:
+      - name: Checkout (push events)
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
       - name: Detect relevant changes
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
           filters: |
             backend:
@@ -77,13 +84,13 @@ jobs:
           --health-retries 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -108,3 +115,32 @@ jobs:
 
       - name: E2E tests
         run: pnpm --filter @apps/api test:e2e
+
+  skip-backend-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.backend != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Skip (no backend changes)
+        run: echo "No backend-related changes detected; skipping heavy checks."
+
+  backend-check:
+    needs: [detect-changes, api-check, skip-backend-check]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate required backend check
+        run: |
+          if [ "${{ needs.detect-changes.outputs.backend }}" = "true" ]; then
+            if [ "${{ needs.api-check.result }}" != "success" ]; then
+              echo "Backend changes were detected but api-check did not succeed."
+              exit 1
+            fi
+            echo "Backend changes detected and api-check succeeded."
+          else
+            echo "No backend changes detected; backend check passes."
+          fi

--- a/.github/workflows/design-system-ci.yml
+++ b/.github/workflows/design-system-ci.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Detect relevant changes
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
           filters: |
             design_system:
@@ -43,15 +43,15 @@ jobs:
 
       - name: Checkout
         if: steps.changes.outputs.design_system == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup pnpm
         if: steps.changes.outputs.design_system == 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
 
       - name: Setup Node
         if: steps.changes.outputs.design_system == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/design-system-ci.yml
+++ b/.github/workflows/design-system-ci.yml
@@ -13,15 +13,7 @@ on:
       - "turbo.json"
       - "tsconfig.base.json"
   pull_request:
-    paths:
-      - "apps/storybook/**"
-      - "packages/ui/**"
-      - ".github/workflows/design-system-ci.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "turbo.json"
-      - "tsconfig.base.json"
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: design-system-ci-${{ github.workflow }}-${{ github.ref }}
@@ -31,30 +23,59 @@ jobs:
   design-system-check:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
+      - name: Detect relevant changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            design_system:
+              - "apps/storybook/**"
+              - "packages/ui/**"
+              - ".github/workflows/design-system-ci.yml"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
+              - "turbo.json"
+              - "tsconfig.base.json"
+
       - name: Checkout
+        if: steps.changes.outputs.design_system == 'true'
         uses: actions/checkout@v4
 
       - name: Setup pnpm
+        if: steps.changes.outputs.design_system == 'true'
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
+        if: steps.changes.outputs.design_system == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
 
       - name: Install dependencies
+        if: steps.changes.outputs.design_system == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: UI typecheck
+        if: steps.changes.outputs.design_system == 'true'
         run: pnpm --filter @repo/ui typecheck
 
       - name: Storybook typecheck
+        if: steps.changes.outputs.design_system == 'true'
         run: pnpm --filter @repo/storybook typecheck
 
       - name: Storybook tests
+        if: steps.changes.outputs.design_system == 'true'
         run: pnpm --filter @repo/storybook test
 
       - name: Storybook build
+        if: steps.changes.outputs.design_system == 'true'
         run: pnpm --filter @repo/storybook build-storybook
+
+      - name: Skip (no design-system changes)
+        if: steps.changes.outputs.design_system != 'true'
+        run: echo "No design-system changes detected; skipping heavy checks."

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Detect relevant changes
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
           filters: |
             web:
@@ -45,15 +45,15 @@ jobs:
 
       - name: Checkout
         if: steps.changes.outputs.web == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup pnpm
         if: steps.changes.outputs.web == 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
 
       - name: Setup Node
         if: steps.changes.outputs.web == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -14,16 +14,7 @@ on:
       - "turbo.json"
       - "tsconfig.base.json"
   pull_request:
-    paths:
-      - "apps/web/**"
-      - "packages/ui/**"
-      - "packages/contracts-auth/**"
-      - ".github/workflows/web-ci.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "turbo.json"
-      - "tsconfig.base.json"
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: web-ci-${{ github.workflow }}-${{ github.ref }}
@@ -33,30 +24,60 @@ jobs:
   web-check:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: read
     steps:
+      - name: Detect relevant changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            web:
+              - "apps/web/**"
+              - "packages/ui/**"
+              - "packages/contracts-auth/**"
+              - ".github/workflows/web-ci.yml"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
+              - "turbo.json"
+              - "tsconfig.base.json"
+
       - name: Checkout
+        if: steps.changes.outputs.web == 'true'
         uses: actions/checkout@v4
 
       - name: Setup pnpm
+        if: steps.changes.outputs.web == 'true'
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
+        if: steps.changes.outputs.web == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
 
       - name: Install dependencies
+        if: steps.changes.outputs.web == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browser
+        if: steps.changes.outputs.web == 'true'
         run: pnpm --filter @apps/web exec playwright install --with-deps chromium
 
       - name: Web typecheck
+        if: steps.changes.outputs.web == 'true'
         run: pnpm --filter @apps/web typecheck
 
       - name: Web unit/integration tests
+        if: steps.changes.outputs.web == 'true'
         run: pnpm --filter @apps/web test
 
       - name: Web e2e tests
+        if: steps.changes.outputs.web == 'true'
         run: pnpm --filter @apps/web test:e2e
+
+      - name: Skip (no web changes)
+        if: steps.changes.outputs.web != 'true'
+        run: echo "No web-related changes detected; skipping heavy checks."


### PR DESCRIPTION
## Summary

Fix intermittent “Expected — Waiting for status to be reported” on PRs by ensuring required workflows always create check runs, while still avoiding unnecessary heavy
CI work.

## Problem

Some required checks (web-ci, backend-ci, design-system-check) did not run on certain PRs because pull_request.paths filters prevented workflow creation.
When a required workflow never starts, branch protection can block merge with “expected check not found”.

## Changes

### 1) Always trigger required workflows on PR events

Updated PR trigger for:

- .github/workflows/web-ci.yml
- .github/workflows/backend-ci.yml
- .github/workflows/design-system-ci.yml

From path-filtered pull_request to:

- types: [opened, synchronize, reopened, ready_for_review]

### 2) Keep CI efficient with file-change detection

Added dorny/paths-filter@v3 inside workflows to detect relevant file changes and conditionally run heavy steps.

- web-ci: runs heavy web steps only when web-related files changed
- design-system-ci: runs heavy design-system steps only when related files changed
- backend-ci: added detect-changes job and made api-check job conditional so Postgres/Redis services only start when backend-related files changed

### 3) Least-privilege permissions

Added:

- permissions: contents: read
  for these workflows/jobs.

## Expected Result

- Required checks always appear on PRs (no more missing/expected-only checks).
- CI cost/time is reduced for unrelated changes.
- Backend services spin up only when backend work is relevant.

## Files Changed

- .github/workflows/web-ci.yml
- .github/workflows/backend-ci.yml
- .github/workflows/design-system-ci.yml

@codex /codex code review