### PR TITLE
ci: fix paths-filter git exit 128 in web/design-system workflows

### DIFF
--- a/.github/workflows/design-system-ci.yml
+++ b/.github/workflows/design-system-ci.yml
@@ -25,7 +25,14 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      pull-requests: read
     steps:
+      - name: Checkout (push events)
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
       - name: Detect relevant changes
         id: changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -26,7 +26,14 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+      pull-requests: read
     steps:
+      - name: Checkout (push events)
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
       - name: Detect relevant changes
         id: changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2


### PR DESCRIPTION
## Summary

This PR fixes intermittent CI failures in web-check and design-system-check where /usr/bin/git exited with code 128
during dorny/paths-filter.

## Changes

- Updated .github/workflows/web-ci.yml
    - Added pull-requests: read permission
    - Added pre-step checkout for push events with fetch-depth: 0 before paths-filter
- Updated .github/workflows/design-system-ci.yml
    - Added pull-requests: read permission
    - Added pre-step checkout for push events with fetch-depth: 0 before paths-filter

## Why

dorny/paths-filter can require PR file-read permission on PR events and a valid git context on push events. Without
that, the workflow may fail with git 128.

## Expected Result

- web-check and design-system-check run reliably on both pull_request and push.
- No more git 128 failures in change-detection step.