### PR TITLE
docs: add Spec Kit progress dashboard and README sync governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,3 +33,11 @@ Source of truth: `.github/workflows/branch-name-policy.yml`
 1. Check current branch: `git branch --show-current`
 2. Create a valid branch: `git checkout -b feature/<task-name>`
 3. Verify branch name again: `git branch --show-current`
+
+## README Sync Rule (Mandatory)
+
+- For every merged feature, `README.md` must be updated.
+- Minimum required updates:
+  1. `Spec Kit Delivery Progress` row (status/date/link)
+  2. `Spec History` dated link (`specs/history/YYYY-MM-DD.md`)
+- A feature is not fully done until README progress/history is synced.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,53 @@ Monorepo for building and validating a spec-driven product workflow with:
 
 This repository uses **Spec Kit** as the default delivery process.
 
+## Spec Kit Delivery Progress
+
+Current delivery visibility (spec folders `01` to `10`):
+
+| Spec ID | Feature | Status | Last Update | Link |
+| --- | --- | --- | --- | --- |
+| 01 | Design System Foundation + shadcn/ui Ownership | Implemented | 2026-02-24 | `specs/01-design-system/` |
+| 02 | Email Auth Backend | Implemented | 2026-02-23 | `specs/02-email-auth-backend/` |
+| 03 | Email Auth Frontend | Implemented | 2026-02-23 | `specs/03-email-auth-frontend/` |
+| 04 | Codex Issue Autoflow | Implemented | 2026-02-26 | `specs/04-codex-issue-autoflow/` |
+| 05 | Codex Telegram Issue Notify | Implemented | 2026-02-27 | `specs/05-codex-telegram-issue-notify/` |
+| 06 | Codex Health Check | Implemented | 2026-02-28 | `specs/06-codex-health-check/` |
+| 07 | API Docs Swagger | Implemented | 2026-03-01 | `specs/07-api-docs-swagger/` |
+| 08 | Channel Governance | Implemented | 2026-03-03 | `specs/08-channel-governance/` |
+| 09 | Channel Posts | Implemented | 2026-03-04 | `specs/09-channel-posts/` |
+| 10 | GitHub Coverage Reporting | Implemented | 2026-03-05 | `specs/10-github-coverage-reporting/` |
+
+Spec Kit + Codex baseline:
+- Spec-first delivery (`spec -> plan -> tasks -> implementation`) is now the repository default.
+- Recent CI improvements include required-check stability, GitHub coverage summary/artifacts, and Telegram coverage notifications.
+
+## Spec History
+
+Date-based entries:
+
+- 2026-02-23: [`specs/history/2026-02-23.md`](./specs/history/2026-02-23.md)
+- 2026-03-05: [`specs/history/2026-03-05.md`](./specs/history/2026-03-05.md)
+
+Rule:
+- For every merged feature, add one dated entry under `specs/history/` and update this section link list.
+
+## README Update Policy (Mandatory)
+
+When a new feature branch is merged, update `README.md` in the same PR (or immediately after merge) with this checklist:
+
+1. Update `Spec Kit Delivery Progress`:
+   - Add new spec row (next ID)
+   - Set status and last update date (`YYYY-MM-DD`)
+   - Add spec folder link
+2. Update `Spec History`:
+   - Add a dated link entry under `specs/history/`
+3. Keep sections concise:
+   - README = overview and links
+   - Detailed logs stay in `specs/<id>-*/` or `specs/history/*.md`
+4. Sync rule:
+   - No feature is considered fully done until README progress/history is updated.
+
 ## What We Are Building
 
 Current implemented focus:

--- a/specs/11-readme-spec-kit-progress-history/plan.md
+++ b/specs/11-readme-spec-kit-progress-history/plan.md
@@ -1,0 +1,41 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Implementation Plan: README Spec Kit Progress & History
+
+**Branch**: `feature/readme-spec-kit-progress-history` | **Date**: 2026-03-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/11-readme-spec-kit-progress-history/spec.md`
+
+## Overview
+
+문서 중심 개선으로 README 가시성을 높인다.
+
+- 현재 Spec Kit 납품 범위/상태를 README에 표준 형식으로 노출
+- 날짜 기반 history 링크 제공
+- 히스토리 갱신 규칙 명문화
+
+## Tech Stack Alignment
+
+- Documentation: Markdown
+- Workflow: Spec Kit (`spec -> plan -> tasks`)
+
+`specs/00-tech-stack.md`와 충돌 없음.
+
+## Changes
+
+- `README.md`
+  - `Spec Kit Delivery Progress` 섹션 추가
+  - `Spec History` 섹션 추가
+  - 히스토리 업데이트 규칙 추가
+- `specs/history/2026-03-05.md`
+  - 최근 작업(coverage + telegram + CI 안정화) 요약 기록
+
+## Risks & Mitigations
+
+- 진행 상태 표의 신뢰성 저하 위험: spec 폴더 기준으로 링크 중심 정보 제공
+- 히스토리 누락 위험: README에 신규 머지 시 기록 규칙 고정
+
+## Delivery Phases
+
+1. spec/plan/tasks 작성
+2. README 섹션 추가
+3. `specs/history` 날짜 문서 추가

--- a/specs/11-readme-spec-kit-progress-history/spec.md
+++ b/specs/11-readme-spec-kit-progress-history/spec.md
@@ -1,0 +1,37 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Feature Specification: README Spec Kit Progress & History
+
+**Feature Branch**: `feature/readme-spec-kit-progress-history`  
+**Created**: 2026-03-05  
+**Status**: Draft  
+**Input**: "show how much we developed with Spec Kit + Codex, and what was tried with dates"
+
+## Summary
+
+README에 Spec Kit 기반 진행 현황과 날짜 기반 시도 이력(History) 진입점을 명확히 추가한다.
+
+## Scope
+
+### In Scope
+
+- `README.md`에 Spec Kit 진행 현황 섹션 추가
+- `README.md`에 날짜 기반 히스토리 링크 섹션 추가
+- `specs/history`에 최신 날짜 이력 문서 추가
+
+### Out of Scope
+
+- 기존 기능 코드 변경
+- 과거 모든 히스토리 문서 상세 재작성
+
+## Functional Requirements
+
+- **FR-RH-001**: README는 현재 Spec Kit 진행 현황을 표 형태로 제공해야 한다.
+- **FR-RH-002**: README는 날짜 기반 히스토리 링크를 제공해야 한다.
+- **FR-RH-003**: 새로운 히스토리 문서에는 날짜, 시도 내용, 결과가 포함되어야 한다.
+- **FR-RH-004**: README는 앞으로의 히스토리 기록 규칙(신규 머지 시 날짜 엔트리 추가)을 명시해야 한다.
+
+## Success Criteria
+
+- **SC-RH-001**: 신규 팀원이 README만 보고 현재 Spec Kit 진행 상태를 파악할 수 있다.
+- **SC-RH-002**: 최근 작업 이력을 날짜 기준으로 빠르게 탐색할 수 있다.

--- a/specs/11-readme-spec-kit-progress-history/tasks.md
+++ b/specs/11-readme-spec-kit-progress-history/tasks.md
@@ -1,0 +1,20 @@
+Tech-Stack: specs/00-tech-stack.md
+
+# Tasks: README Spec Kit Progress & History
+
+## Phase 1: Spec Kit Docs
+
+- [x] RH-T001 `spec.md` 작성
+- [x] RH-T002 `plan.md` 작성
+- [x] RH-T003 `tasks.md` 작성
+
+## Phase 2: README Update
+
+- [x] RH-T004 `Spec Kit Delivery Progress` 섹션 추가
+- [x] RH-T005 `Spec History` 섹션 추가
+- [x] RH-T006 히스토리 기록 규칙 문구 추가
+
+## Phase 3: History Entry
+
+- [x] RH-T007 `specs/history/2026-03-05.md` 추가
+- [x] RH-T008 README와 history 링크 정합성 검증

--- a/specs/history/2026-03-05.md
+++ b/specs/history/2026-03-05.md
@@ -1,0 +1,31 @@
+# Specs History Index - 2026-03-05
+
+오늘 스펙/CI 정제 이력 요약이다. 구현 코드의 세부 diff가 아니라 "무엇을 시도했고 어떤 결과였는지"를 기록한다.
+
+## Tried
+
+1. web/design-system CI에서 `dorny/paths-filter` 실행 시 `/usr/bin/git` exit 128 이슈 대응
+2. GitHub Actions에서 coverage 수치 표시 요구 대응
+3. coverage 결과를 Telegram으로도 알림받고 싶은 요구 대응
+
+## Result
+
+1. `web-ci.yml`, `design-system-ci.yml`
+   - push 이벤트에서 사전 checkout + `fetch-depth: 0` 추가
+   - `pull-requests: read` 권한 명시
+2. coverage reporting
+   - `test:coverage` 스크립트(web/storybook) 추가
+   - Job Summary에 Lines/Statements/Functions/Branches 표시
+   - coverage artifact 업로드
+3. Telegram reporting
+   - `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`가 설정된 경우 coverage 요약 전송
+   - 시크릿 미설정 시 fail 없이 skip
+
+## Related Specs
+
+- [`specs/09-channel-posts/`](../09-channel-posts/)
+- [`specs/10-github-coverage-reporting/`](../10-github-coverage-reporting/)
+
+## Note
+
+- Runtime verification(실제 PR에서 Summary/Artifact/Telegram 확인)은 체크리스트로 분리하여 관리한다.


### PR DESCRIPTION
## Summary

This PR improves project-level delivery visibility and documentation governance for Spec Kit workflows.

## Changes

- Updated README.md:
    - Added Spec Kit Delivery Progress table (spec 01-10 snapshot)
    - Added Spec History dated links
    - Added mandatory README Update Policy checklist for new merged work
- Updated AGENTS.md:
    - Added mandatory README Sync Rule so README progress/history updates are part of done criteria
- Added new Spec Kit docs for this documentation feature:
    - specs/11-readme-spec-kit-progress-history/spec.md
    - specs/11-readme-spec-kit-progress-history/plan.md
    - specs/11-readme-spec-kit-progress-history/tasks.md
- Added dated history entry:
    - specs/history/2026-03-05.md

## Why

- Make it obvious how far delivery has progressed with Spec Kit (+ Codex workflow).
- Keep a date-based “what we tried / what changed” trail.
- Enforce README synchronization so project status stays current.

## Notes

- This PR is documentation/process only; no runtime application behavior changed.